### PR TITLE
Use Multiple Mounts for Container Ephemeral Storage

### DIFF
--- a/build/cache/nuget/.gitignore
+++ b/build/cache/nuget/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/build/cache/yarn/.gitignore
+++ b/build/cache/yarn/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/build/docker/dev/dotnet/Dockerfile
+++ b/build/docker/dev/dotnet/Dockerfile
@@ -7,13 +7,9 @@ RUN addgroup --gid 1000 docker && \
     chown -R docker:docker /dotnet
 
 # install fixuid
-RUN USER=docker && \
-    GROUP=docker && \
-    curl -SsL https://github.com/boxboat/fixuid/releases/download/v0.2/fixuid-0.2-linux-amd64.tar.gz | tar -C /usr/local/bin -xzf - && \
+RUN curl -SsL https://github.com/boxboat/fixuid/releases/download/v0.3/fixuid-0.3-linux-amd64.tar.gz | tar -C /usr/local/bin -xzf - && \
     chown root:root /usr/local/bin/fixuid && \
-    chmod 4755 /usr/local/bin/fixuid && \
-    mkdir -p /etc/fixuid && \
-    printf "user: $USER\ngroup: $GROUP\n" > /etc/fixuid/config.yml
+    chmod 4755 /usr/local/bin/fixuid
 
 # create directories
 RUN mkdir -p /dotnet/src/App/bin && \

--- a/build/docker/dev/dotnet/Dockerfile
+++ b/build/docker/dev/dotnet/Dockerfile
@@ -15,6 +15,17 @@ RUN USER=docker && \
     mkdir -p /etc/fixuid && \
     printf "user: $USER\ngroup: $GROUP\n" > /etc/fixuid/config.yml
 
+# create directories
+RUN mkdir -p /dotnet/src/App/bin && \
+    mkdir -p /dotnet/src/App/obj && \
+    mkdir -p /dotnet/tests/App.Functional/bin && \
+    mkdir -p /dotnet/tests/App.Functional/obj && \
+    mkdir -p /dotnet/tests/App.Unit/bin && \
+    mkdir -p /dotnet/tests/App.Unit/obj && \
+    chown -R docker:docker /dotnet && \
+    mkdir -p /home/docker/.nuget && \
+    chown docker:docker /home/docker/.nuget
+
 # set entrypoint and command
 ENTRYPOINT ["fixuid"]
 CMD ["app-run"]

--- a/build/docker/dev/dotnet/stage/etc/fixuid/config.yml
+++ b/build/docker/dev/dotnet/stage/etc/fixuid/config.yml
@@ -1,0 +1,11 @@
+user: docker
+group: docker
+paths:
+  - /
+  - /dotnet/src/App/bin
+  - /dotnet/src/App/obj
+  - /dotnet/tests/App.Functional/bin
+  - /dotnet/tests/App.Functional/obj
+  - /dotnet/tests/App.Unit/bin
+  - /dotnet/tests/App.Unit/obj
+  - /home/docker/.nuget

--- a/build/docker/dev/dotnet/stage/usr/local/bin/app-run
+++ b/build/docker/dev/dotnet/stage/usr/local/bin/app-run
@@ -1,14 +1,8 @@
 #!/usr/bin/env sh
 
-# remove all of the symlinks if any exist
-find /dotnet -type l -maxdepth 3 -exec rm {} \;
-
-# make symlinks to everything except for `bin` and `obj` folders
-cd /mnt/dotnet
-find * -maxdepth 0 -name "*.sln" | \
-    xargs -I % sh -c 'ln -s "/mnt/dotnet/%" "/dotnet/%";'
-find * -mindepth 2 -maxdepth 2 ! -name "bin" ! -name "obj" | \
-    xargs -I % sh -c 'mkdir -p "/dotnet/$(dirname %)"; ln -s "/mnt/dotnet/%" "/dotnet/%";'
+ls -lh /dotnet/src/App
+ls -lh /dotnet/tests/App.Functional
+ls -lh /dotnet/tests/App.Unit
 
 # restore
 cd /dotnet

--- a/build/docker/dev/ui-ssr/Dockerfile
+++ b/build/docker/dev/ui-ssr/Dockerfile
@@ -4,13 +4,9 @@ FROM node:8.9.0-alpine
 RUN apk update && apk add curl
 
 # install fixuid
-RUN USER=node && \
-    GROUP=node && \
-    curl -SsL https://github.com/boxboat/fixuid/releases/download/v0.2/fixuid-0.2-linux-amd64.tar.gz | tar -C /usr/local/bin -xzf - && \
+RUN curl -SsL https://github.com/boxboat/fixuid/releases/download/v0.3/fixuid-0.3-linux-amd64.tar.gz | tar -C /usr/local/bin -xzf - && \
     chown root:root /usr/local/bin/fixuid && \
-    chmod 4755 /usr/local/bin/fixuid && \
-    mkdir -p /etc/fixuid && \
-    printf "user: $USER\ngroup: $GROUP\n" > /etc/fixuid/config.yml
+    chmod 4755 /usr/local/bin/fixuid
 
 # set entrypoint and command
 ENTRYPOINT ["fixuid"]

--- a/build/docker/dev/ui-ssr/stage/etc/fixuid/config.yml
+++ b/build/docker/dev/ui-ssr/stage/etc/fixuid/config.yml
@@ -1,0 +1,4 @@
+user: node
+group: node
+paths:
+  - /

--- a/build/docker/dev/ui/Dockerfile
+++ b/build/docker/dev/ui/Dockerfile
@@ -4,13 +4,9 @@ FROM node:8.9.0-alpine
 RUN apk update && apk add curl
 
 # install fixuid
-RUN USER=node && \
-    GROUP=node && \
-    curl -SsL https://github.com/boxboat/fixuid/releases/download/v0.2/fixuid-0.2-linux-amd64.tar.gz | tar -C /usr/local/bin -xzf - && \
+RUN curl -SsL https://github.com/boxboat/fixuid/releases/download/v0.3/fixuid-0.3-linux-amd64.tar.gz | tar -C /usr/local/bin -xzf - && \
     chown root:root /usr/local/bin/fixuid && \
-    chmod 4755 /usr/local/bin/fixuid && \
-    mkdir -p /etc/fixuid && \
-    printf "user: $USER\ngroup: $GROUP\n" > /etc/fixuid/config.yml
+    chmod 4755 /usr/local/bin/fixuid
 
 # set entrypoint and command
 ENTRYPOINT ["fixuid"]
@@ -19,8 +15,8 @@ CMD ["app-run"]
 # setup cache dir
 RUN mkdir -p /ui/node_modules && \
     chown -R node:node /ui && \
-    mkdir -p /home/node/.cache && \
-    chown node:node /home/node/.cache
+    mkdir -p /home/node/.cache/yarn && \
+    chown -R node:node /home/node/.cache
 
 # copy staged files
 COPY stage/ /

--- a/build/docker/dev/ui/Dockerfile
+++ b/build/docker/dev/ui/Dockerfile
@@ -17,7 +17,9 @@ ENTRYPOINT ["fixuid"]
 CMD ["app-run"]
 
 # setup cache dir
-RUN mkdir -p /home/node/.cache && \
+RUN mkdir -p /ui/node_modules && \
+    chown -R node:node /ui && \
+    mkdir -p /home/node/.cache && \
     chown node:node /home/node/.cache
 
 # copy staged files

--- a/build/docker/dev/ui/stage/etc/fixuid/config.yml
+++ b/build/docker/dev/ui/stage/etc/fixuid/config.yml
@@ -1,0 +1,6 @@
+user: node
+group: node
+paths:
+  - /
+  - /ui/node_modules
+  - /home/node/.cache/yarn

--- a/build/docker/dev/ui/stage/usr/local/bin/app-run
+++ b/build/docker/dev/ui/stage/usr/local/bin/app-run
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
 
 cd /ui
-yarn install --no-bin-links
+yarn install
 yarn run start

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,9 @@
 version: "3.1"
 
+volumes:
+  nuget-cache:
+  yarn-cache:
+
 services:
 
   db:
@@ -29,8 +33,14 @@ services:
     ports:
       - "48010:5000"
     volumes:
-      - ./dotnet:/mnt/dotnet
-      - ./build/cache/nuget:/home/docker/.nuget
+      - ./dotnet:/dotnet
+      - /dotnet/src/App/bin
+      - /dotnet/src/App/obj
+      - /dotnet/tests/App.Functional/bin
+      - /dotnet/tests/App.Functional/obj
+      - /dotnet/tests/App.Unit/bin
+      - /dotnet/tests/App.Unit/obj
+      - nuget-cache:/home/docker/.nuget
     user: ${FIXUID:-1000}:${FIXGID:-1000}
     depends_on:
       - db
@@ -53,7 +63,8 @@ services:
       - DEVENV=dev
     volumes:
       - ./ui:/ui
-      - ./build/cache/yarn:/home/node/.cache/yarn
+      - /ui/node_modules
+      - yarn-cache:/home/node/.cache/yarn
     user: ${FIXUID:-1000}:${FIXGID:-1000}
 
   nginx:


### PR DESCRIPTION
- Use multiple mounts to ensure that `bin`, `obj`, and `node_modules` folders stay local to the container
- Use `fixuid` v0.3 to correct UID/GID inside of container mounts